### PR TITLE
Handle quoted csv files

### DIFF
--- a/ch.obermuhlner.csv2chart/src/main/java/ch/obermuhlner/csv2chart/Parameters.java
+++ b/ch.obermuhlner.csv2chart/src/main/java/ch/obermuhlner/csv2chart/Parameters.java
@@ -58,6 +58,15 @@ public class Parameters implements Cloneable {
 	public ImageFormat imageFormat = ImageFormat.SVG;
 
 	@Parameter(
+			name = "in.strip",
+			description = ""
+					+ "Strip extra quotes from input files.\n"
+					+ "Default: false",
+			optionName = "strip",
+			optionArgumentDescription = "strip")
+	public boolean strip = false;
+
+	@Parameter(
 			name = "chart",
 			description = ""
 					+ "The chart type to generate.\n"

--- a/ch.obermuhlner.csv2chart/src/test/java/ch/obermuhlner/csv2chart/model/csv/CsvDataModelLoaderTest.java
+++ b/ch.obermuhlner.csv2chart/src/test/java/ch/obermuhlner/csv2chart/model/csv/CsvDataModelLoaderTest.java
@@ -109,4 +109,26 @@ public class CsvDataModelLoaderTest {
 		assertEquals(new DataVector(Arrays.asList("Columns", "Col1"), Arrays.asList("1.1", "2.1")), dataModel.getValues().get(0));
 		assertEquals(new DataVector(Arrays.asList("Columns", "Col2"), Arrays.asList("1.2", "2.2")), dataModel.getValues().get(1));
 	}
+
+	@Test
+	public void testLoad_Quoted_HeaderRow() {
+		CsvDataModelLoader dataModelLoader = new CsvDataModelLoader();
+
+		Matrix<String> matrix = new Matrix<>();
+
+		int row = 0;
+		matrix.setRow(row++, "\"Col1\"", "\"Col2\"");
+		matrix.setRow(row++, "\"1.1\"", "\"1.2\"");
+		matrix.setRow(row++, "\"2.1\"", "\"2.2\"");
+
+		Parameters parameters = new Parameters();
+		parameters.strip = true;
+		DataModel dataModel = dataModelLoader.load(matrix, parameters);
+
+		assertEquals(null, dataModel.getCategory());
+
+		assertEquals(2, dataModel.getValues().size());
+		assertEquals(new DataVector(Arrays.asList("Col1"), Arrays.asList("1.1", "2.1")), dataModel.getValues().get(0));
+		assertEquals(new DataVector(Arrays.asList("Col2"), Arrays.asList("1.2", "2.2")), dataModel.getValues().get(1));
+	}
 }


### PR DESCRIPTION
When using a tool like snowsql to acquire the csv, every cell is quoted (including the numbers). This prevents csv2chart from processing the information correctly.

This change provides an optional parameter `in.strip` that defaults to false. 
When enabled, it will remove the surrounding quotes, if they exist.

Test added as well.

Verified with data loaded from snowsql that it works now.